### PR TITLE
Remove dependency on cssify

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,16 +27,6 @@
     "develop": "done-serve --static --develop --port 8080"
   },
   "main": "dist/cjs/can-list-sort",
-  "browser": {
-    "transform": [
-      "cssify"
-    ]
-  },
-  "browserify": {
-    "transform": [
-      "cssify"
-    ]
-  },
   "keywords": [
     "canjs"
   ],
@@ -64,7 +54,6 @@
     "can-compute": "^3.0.1",
     "can-model": "^3.0.0-pre.1",
     "can-stache": "^3.0.2",
-    "cssify": "^0.6.0",
     "documentjs": "^0.4.2",
     "done-serve": "^0.3.0-pre.0",
     "donejs-cli": "^0.10.0-pre.0",


### PR DESCRIPTION
This project doesn't use cssify and it breaks Browserify usage.