### PR TITLE
Fix failling tests

### DIFF
--- a/can-list-sort-test.js
+++ b/can-list-sort-test.js
@@ -468,22 +468,22 @@ test("removing comparator tears down bubbling", function(){
 
 	heroes.bind("length",lengthHandler);
 
-	ok(!heroes[0]._bindings, "item has no bindings");
+	ok(!heroes[0].__bindEvents, "item has no bindings");
 
 	heroes.attr('comparator', 'id');
 
 	heroes.attr("0.id",3);
 
-	ok(heroes._bindings, "list has bindings");
-	ok(heroes[0]._bindings, "item has bindings");
+	ok(heroes.__bindEvents._lifecycleBindings, "list has bindings");
+	ok(heroes[0].__bindEvents._lifecycleBindings, "item has bindings");
 
 	heroes.removeAttr('comparator');
 
-	ok(!heroes[0]._bindings, "has bindings");
-	ok(heroes._bindings, "list has bindings");
+	ok(!heroes[0].__bindEvents._lifecycleBindings, "item has no bindings");
+	ok(heroes.__bindEvents._lifecycleBindings, "list has bindings");
 
 	heroes.unbind("length",lengthHandler);
-	ok(!heroes._bindings, "list has no bindings");
+	ok(!heroes.__bindEvents._lifecycleBindings, "list has no bindings");
 });
 
 test('sorting works when returning any negative value (#1601)', function() {

--- a/can-list-sort.js
+++ b/can-list-sort.js
@@ -87,7 +87,7 @@ assign(proto, {
 		if( newValue || newValue === 0 ) {
 			this.sort();
 
-			if(this._bindings > 0 && ! this._comparatorBound) {
+			if((this.__bindEvents && this.__bindEvents._lifecycleBindings > 0) && ! this._comparatorBound) {
 				this.bind("change", this._comparatorBound = function(){});
 			}
 		} else if(this._comparatorBound){
@@ -99,7 +99,7 @@ assign(proto, {
 	unbind: function(){
 		var res = unbind.apply(this, arguments);
 
-		if(this._comparatorBound && this._bindings === 1) {
+		if(this._comparatorBound && (this.__bindEvents && this.__bindEvents._lifecycleBindings === 1 )) {
 			unbind.call(this,"change", this._comparatorBound);
 			this._comparatorBound = false;
 		}


### PR DESCRIPTION
closes #1 for can-list

changing _bindings to __bindEvents._lifecycleBindings in order to fix… failing tests